### PR TITLE
#10 Refactor on the settings logic so it uses the ThemeMode at ViewModel level.

### DIFF
--- a/settings/build.gradle.kts
+++ b/settings/build.gradle.kts
@@ -52,6 +52,7 @@ android {
 }
 
 dependencies {
+    debugApi(Deps.composePreview)
     implementation(project(":coreUi"))
     implementation(project(":sessionCore"))
     implementation(project(":core"))

--- a/settings/src/main/java/com/joasvpereira/settings/compose/main/SettingMainView.kt
+++ b/settings/src/main/java/com/joasvpereira/settings/compose/main/SettingMainView.kt
@@ -19,12 +19,6 @@ import pt.joasvpereira.coreui.scaffold.ToolBarConfig
 import pt.joasvpereira.coreui.theme.DynamicTheme
 import pt.joasvpereira.coreui.theme.ThemeOption
 
-fun ThemePreference.ThemeMode.getId(): Int = when (this) {
-    ThemePreference.ThemeMode.DEFAULT -> 0
-    ThemePreference.ThemeMode.LIGHT -> 1
-    ThemePreference.ThemeMode.DARK -> 2
-}
-
 @Composable
 fun SettingsMainView(
     onBackClick: () -> Unit,
@@ -68,17 +62,8 @@ fun SettingsMainView(
                     hasMaterialYou = hasMaterialYou,
                     isMaterialYouEnabled = isMaterialYouEnabled,
                     onMaterialYouSwitchChange = onMaterialYouSwitchChange,
-                    themeModeSelectedOption = themeModeSelectedOption.getId(),
-                    onThemeModeChange = {
-                        // TODO: this need to be refactor
-                        onThemeModeChange(
-                            when (it) {
-                                1 -> ThemePreference.ThemeMode.LIGHT
-                                2 -> ThemePreference.ThemeMode.DARK
-                                else -> ThemePreference.ThemeMode.DEFAULT
-                            },
-                        )
-                    },
+                    themeModeSelectedOption = themeModeSelectedOption,
+                    onThemeModeChange = onThemeModeChange,
                 )
             }
         }
@@ -118,7 +103,7 @@ fun SettingsMainViewPreview(@PreviewParameter(ThemesProvider::class) theme: Them
             hasMaterialYou = true,
             isMaterialYouEnabled = false,
             onMaterialYouSwitchChange = {},
-            themeModeSelectedOption = ThemePreference.ThemeMode.LIGHT,
+            themeModeSelectedOption = ThemePreference.ThemeMode.DEFAULT,
             onThemeModeChange = {},
             onLogout = {},
         )

--- a/settings/src/main/java/com/joasvpereira/settings/compose/main/menu/entry/EntryWithSelectableOption.kt
+++ b/settings/src/main/java/com/joasvpereira/settings/compose/main/menu/entry/EntryWithSelectableOption.kt
@@ -48,6 +48,8 @@ fun EntryWithSelectableOption(
     selectedOption: Int = 0,
     onOptionChanged: (Int) -> Unit,
 ) {
+    if (selectedOption < 0 && selectedOption >= listOfOptions.size) return
+
     var isOptionsOpen by remember {
         mutableStateOf(false)
     }

--- a/settings/src/main/java/com/joasvpereira/settings/compose/main/theme/ThemeSettingsSection.kt
+++ b/settings/src/main/java/com/joasvpereira/settings/compose/main/theme/ThemeSettingsSection.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.joasvpereira.dev.mokeupui.compose.screen.organizer.main.SimpleSpace
 import com.joasvpereira.settings.compose.main.SettingsSection
 import com.joasvpereira.settings.compose.main.menu.entry.EntryWithSelectableOption
 import com.joasvpereira.settings.compose.main.menu.entry.EntryWithSwitch
+import com.joasvpereira.settings.data.ThemeModeMapper
+import pt.joasvpereira.core.settings.domain.data.ThemePreference
 import pt.joasvpereira.coreui.preview.UiModePreview
 import pt.joasvpereira.coreui.theme.DynamicTheme
 
@@ -20,8 +23,8 @@ internal fun ThemeSettingsSection(
     hasMaterialYou: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
     isMaterialYouEnabled: Boolean,
     onMaterialYouSwitchChange: (Boolean) -> Unit,
-    themeModeSelectedOption: Int,
-    onThemeModeChange: (Int) -> Unit,
+    themeModeSelectedOption: ThemePreference.ThemeMode,
+    onThemeModeChange: (ThemePreference.ThemeMode) -> Unit,
 ) {
     SettingsSection(
         modifier = modifier,
@@ -38,17 +41,27 @@ internal fun ThemeSettingsSection(
             SimpleSpace(size = 20.dp)
         }
 
+        val context = LocalContext.current
+        val allModes = ThemePreference.ThemeMode.values().asList()
+        val selectedOption = allModes.first { it == themeModeSelectedOption }
+        val selectedOptionLabel = ThemeModeMapper.mapToString(context, selectedOption)
+        val list = allModes.map {
+            ThemeModeMapper.mapToString(context, it)
+        }
+
         EntryWithSelectableOption(
             text = "Theme mode",
-            listOfOptions = listOf("Default", "Light", "Dark"),
+            listOfOptions = list,
             description = """
                 You can choose 3 different options:                 
                   - Default, that will use the system light or dark mode;
                   - Light, will force the app to be on Light mode;
                   - Dark, will force the app to be on Dark mode;
             """.trimIndent(),
-            selectedOption = themeModeSelectedOption,
-            onOptionChanged = onThemeModeChange,
+            selectedOption = list.indexOf(selectedOptionLabel),
+            onOptionChanged = { index ->
+                onThemeModeChange(ThemeModeMapper.mapFromString(context, list[index]))
+            },
         )
 
         SimpleSpace(size = 20.dp)
@@ -68,7 +81,7 @@ private fun ThemeSettingsSectionPreview() {
                 hasMaterialYou = true,
                 isMaterialYouEnabled = false,
                 onMaterialYouSwitchChange = {},
-                themeModeSelectedOption = 2,
+                themeModeSelectedOption = ThemePreference.ThemeMode.DEFAULT,
                 onThemeModeChange = {},
             )
         }

--- a/settings/src/main/java/com/joasvpereira/settings/data/ThemeModeMapper.kt
+++ b/settings/src/main/java/com/joasvpereira/settings/data/ThemeModeMapper.kt
@@ -1,0 +1,24 @@
+package com.joasvpereira.settings.data
+
+import android.content.Context
+import com.joasvpereira.settings.R
+import pt.joasvpereira.core.settings.domain.data.ThemePreference
+
+object ThemeModeMapper {
+    fun mapToString(context: Context, themeMode: ThemePreference.ThemeMode): String {
+        return when (themeMode) {
+            ThemePreference.ThemeMode.DEFAULT -> context.getString(R.string.theme_mode_default_lable)
+            ThemePreference.ThemeMode.LIGHT -> context.getString(R.string.theme_mode_light_lable)
+            ThemePreference.ThemeMode.DARK -> context.getString(R.string.theme_mode_dark_lable)
+        }
+    }
+
+    fun mapFromString(context: Context, themeModeLabel: String): ThemePreference.ThemeMode {
+        return when (themeModeLabel) {
+            context.getString(R.string.theme_mode_default_lable) -> ThemePreference.ThemeMode.DEFAULT
+            context.getString(R.string.theme_mode_light_lable) -> ThemePreference.ThemeMode.LIGHT
+            context.getString(R.string.theme_mode_dark_lable) -> ThemePreference.ThemeMode.DARK
+            else -> throw ThemeModeNotFoundException("No theme mode for label \"$themeModeLabel\" note found.")
+        }
+    }
+}

--- a/settings/src/main/java/com/joasvpereira/settings/data/ThemeModeNotFoundException.kt
+++ b/settings/src/main/java/com/joasvpereira/settings/data/ThemeModeNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.joasvpereira.settings.data
+
+class ThemeModeNotFoundException(override val message: String?) : Exception()

--- a/settings/src/main/res/values-pt-rPT/strings.xml
+++ b/settings/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="theme_mode_default_lable">Default</string>
+    <string name="theme_mode_light_lable">Light</string>
+    <string name="theme_mode_dark_lable">Dark</string>
+</resources>

--- a/settings/src/main/res/values/strings.xml
+++ b/settings/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="theme_mode_default_lable">Default</string>
+    <string name="theme_mode_light_lable">Light</string>
+    <string name="theme_mode_dark_lable">Dark</string>
+</resources>


### PR DESCRIPTION
#10 refactor Settings theme selector logic to not use a magic numbers to assert the selected mode, know all logic uses ThemeMode with the help of ThemeModeMapper.